### PR TITLE
Templatize `NDTPPayloadBroadband`

### DIFF
--- a/include/science/libndtp/ndtp.h
+++ b/include/science/libndtp/ndtp.h
@@ -43,16 +43,19 @@ struct NDTPHeader {
 /**
  * NDTPPayloadBroadband represents broadband payload data.
  */
-struct NDTPPayloadBroadband {
+template <typename T>
+struct GenericNDTPPayloadBroadband {
+
   struct ChannelData {
     uint32_t channel_id;  // 24-bit
-    std::vector<uint64_t> channel_data;
+    std::vector<T> channel_data;
 
     bool operator==(const ChannelData& other) const {
       return channel_id == other.channel_id && channel_data == other.channel_data;
     }
 
     bool operator!=(const ChannelData& other) const { return !(*this == other); }
+
   };
 
   bool is_signed;        // 1 bit
@@ -62,17 +65,19 @@ struct NDTPPayloadBroadband {
   std::vector<ChannelData> channels;
 
   ByteArray pack() const;
-  static NDTPPayloadBroadband unpack(const ByteArray& data);
+  static GenericNDTPPayloadBroadband<uint64_t> unpack(const ByteArray& data);
 
-  bool operator==(const NDTPPayloadBroadband& other) const {
+  bool operator==(const GenericNDTPPayloadBroadband& other) const {
     return is_signed == other.is_signed &&
             bit_width == other.bit_width &&
             sample_rate == other.sample_rate &&
             channels == other.channels;
   }
 
-  bool operator!=(const NDTPPayloadBroadband& other) const { return !(*this == other); }
+  bool operator!=(const GenericNDTPPayloadBroadband& other) const { return !(*this == other); }
 };
+
+typedef GenericNDTPPayloadBroadband<uint64_t> NDTPPayloadBroadband;
 
 /**
  * NDTPPayloadSpiketrain represents spiketrain payload data.

--- a/include/science/libndtp/ndtp.h
+++ b/include/science/libndtp/ndtp.h
@@ -64,7 +64,6 @@ struct GenericNDTPPayloadBroadband {
   uint32_t sample_rate;  // 2 bytes
   std::vector<ChannelData> channels;
 
-  ByteArray pack() const;
   static GenericNDTPPayloadBroadband<uint64_t> unpack(const ByteArray& data);
 
   bool operator==(const GenericNDTPPayloadBroadband& other) const {
@@ -75,6 +74,45 @@ struct GenericNDTPPayloadBroadband {
   }
 
   bool operator!=(const GenericNDTPPayloadBroadband& other) const { return !(*this == other); }
+
+  ByteArray pack() const {
+    ByteArray payload;
+
+    // First byte: bit width and signed flag
+    payload.push_back(((bit_width & 0x7F) << 1) | (is_signed ? 1 : 0));
+
+    // Next three bytes: number of channels
+    uint32_t n_channels = channels.size();
+    payload.push_back((n_channels >> 16) & 0xFF);
+    payload.push_back((n_channels >> 8) & 0xFF);
+    payload.push_back((n_channels) & 0xFF);
+
+    // Next three bytes: sample rate
+    uint32_t n_sample_rate = sample_rate;
+    payload.push_back((n_sample_rate >> 16) & 0xFF);
+    payload.push_back((n_sample_rate >> 8) & 0xFF);
+    payload.push_back(n_sample_rate & 0xFF);
+
+    size_t bit_offset = 0;
+    for (const auto& c : channels) {
+      size_t num_samples = c.channel_data.size();
+      if (num_samples > 0xFFFF) {
+        throw std::runtime_error("number of samples is too large, must be less than 65536");
+      }
+
+      auto p_cid = to_bytes<uint32_t>({c.channel_id}, 24, payload, bit_offset);
+      bit_offset = std::get<1>(p_cid);
+
+      auto p_num_samples = to_bytes<uint16_t>({static_cast<uint16_t>(num_samples)}, 16, payload, bit_offset);
+      bit_offset = std::get<1>(p_num_samples);
+
+      auto p_channel_data = to_bytes<T>(c.channel_data, bit_width, payload, bit_offset, is_signed);
+      bit_offset = std::get<1>(p_channel_data);
+    }
+
+    return payload;
+  }
+
 };
 
 typedef GenericNDTPPayloadBroadband<uint64_t> NDTPPayloadBroadband;

--- a/include/science/libndtp/utils.h
+++ b/include/science/libndtp/utils.h
@@ -49,13 +49,13 @@ std::tuple<ByteArray, BitOffset, bool> to_bytes(
   writing_bit_offset = writing_bit_offset % 8;
 
   ByteArray& result = existing;
-  // if (!existing.empty()) {
-  //   if (truncate_bytes < static_cast<int>(existing.size())) {
-  //     result.erase(result.begin(), result.begin() + truncate_bytes);
-  //   } else {
-  //     result.clear();
-  //   }
-  // }
+  if (!existing.empty()) {
+    if (truncate_bytes < static_cast<int>(existing.size())) {
+      result.erase(result.begin(), result.begin() + truncate_bytes);
+    } else {
+      result.clear();
+    }
+  }
 
   bool continue_last = !existing.empty() && writing_bit_offset > 0;
   uint8_t current_byte = (continue_last && !result.empty()) ? result.back() : 0;

--- a/include/science/libndtp/utils.h
+++ b/include/science/libndtp/utils.h
@@ -36,7 +36,7 @@ template <typename T>
 std::tuple<ByteArray, BitOffset, bool> to_bytes(
     const std::vector<T>& values,
     uint8_t bit_width,
-    const ByteArray& existing = {},
+    ByteArray& existing = {},
     size_t writing_bit_offset = 0,
     bool is_signed = false,
     bool is_le = false
@@ -48,14 +48,14 @@ std::tuple<ByteArray, BitOffset, bool> to_bytes(
   size_t truncate_bytes = writing_bit_offset / 8;
   writing_bit_offset = writing_bit_offset % 8;
 
-  ByteArray result = existing;
-  if (!existing.empty()) {
-    if (truncate_bytes < static_cast<int>(existing.size())) {
-      result.erase(result.begin(), result.begin() + truncate_bytes);
-    } else {
-      result.clear();
-    }
-  }
+  ByteArray& result = existing;
+  // if (!existing.empty()) {
+  //   if (truncate_bytes < static_cast<int>(existing.size())) {
+  //     result.erase(result.begin(), result.begin() + truncate_bytes);
+  //   } else {
+  //     result.clear();
+  //   }
+  // }
 
   bool continue_last = !existing.empty() && writing_bit_offset > 0;
   uint8_t current_byte = (continue_last && !result.empty()) ? result.back() : 0;

--- a/include/science/libndtp/utils.h
+++ b/include/science/libndtp/utils.h
@@ -36,7 +36,7 @@ template <typename T>
 std::tuple<ByteArray, BitOffset, bool> to_bytes(
     const std::vector<T>& values,
     uint8_t bit_width,
-    ByteArray& existing = {},
+    ByteArray& existing,
     size_t writing_bit_offset = 0,
     bool is_signed = false,
     bool is_le = false
@@ -104,6 +104,17 @@ std::tuple<ByteArray, BitOffset, bool> to_bytes(
   return { result, bits_in_current_byte, status_good };
 }
 
+template <typename T>
+std::tuple<ByteArray, BitOffset, bool> to_bytes(
+    const std::vector<T>& values,
+    uint8_t bit_width,
+    size_t writing_bit_offset = 0,
+    bool is_signed = false,
+    bool is_le = false
+) { 
+  ByteArray existing = {};
+  return to_bytes(values, bit_width, existing, writing_bit_offset, is_signed, is_le);
+}
 
 /**
  * Parses a list of integers from a byte array with the specified bit width.

--- a/include/science/libndtp/utils.h
+++ b/include/science/libndtp/utils.h
@@ -49,13 +49,13 @@ std::tuple<ByteArray, BitOffset, bool> to_bytes(
   writing_bit_offset = writing_bit_offset % 8;
 
   ByteArray& result = existing;
-  if (!existing.empty()) {
-    if (truncate_bytes < static_cast<int>(existing.size())) {
-      result.erase(result.begin(), result.begin() + truncate_bytes);
-    } else {
-      result.clear();
-    }
-  }
+  // if (!existing.empty()) {
+  //   if (truncate_bytes < static_cast<int>(existing.size())) {
+  //     result.erase(result.begin(), result.begin() + truncate_bytes);
+  //   } else {
+  //     result.clear();
+  //   }
+  // }
 
   bool continue_last = !existing.empty() && writing_bit_offset > 0;
   uint8_t current_byte = (continue_last && !result.empty()) ? result.back() : 0;

--- a/include/science/libndtp/utils.h
+++ b/include/science/libndtp/utils.h
@@ -49,13 +49,6 @@ std::tuple<ByteArray, BitOffset, bool> to_bytes(
   writing_bit_offset = writing_bit_offset % 8;
 
   ByteArray& result = existing;
-  // if (!existing.empty()) {
-  //   if (truncate_bytes < static_cast<int>(existing.size())) {
-  //     result.erase(result.begin(), result.begin() + truncate_bytes);
-  //   } else {
-  //     result.clear();
-  //   }
-  // }
 
   bool continue_last = !existing.empty() && writing_bit_offset > 0;
   uint8_t current_byte = (continue_last && !result.empty()) ? result.back() : 0;

--- a/src/science/libndtp/ndtp.cpp
+++ b/src/science/libndtp/ndtp.cpp
@@ -69,7 +69,8 @@ NDTPHeader NDTPHeader::unpack(const ByteArray& data) {
   return NDTPHeader{version, data_type, ntohll(n_timestamp), ntohs(n_seq_number)};
 }
 
-ByteArray NDTPPayloadBroadband::pack() const {
+template <typename Tinteger>
+ByteArray GenericNDTPPayloadBroadband<Tinteger>::pack() const {
   ByteArray payload;
 
   // First byte: bit width and signed flag
@@ -100,14 +101,15 @@ ByteArray NDTPPayloadBroadband::pack() const {
     auto p_num_samples = to_bytes<uint16_t>({static_cast<uint16_t>(num_samples)}, 16, payload, bit_offset);
     bit_offset = std::get<1>(p_num_samples);
 
-    auto p_channel_data = to_bytes<uint64_t>(c.channel_data, bit_width, payload, bit_offset, is_signed);
+    auto p_channel_data = to_bytes<Tinteger>(c.channel_data, bit_width, payload, bit_offset, is_signed);
     bit_offset = std::get<1>(p_channel_data);
   }
 
   return payload;
 }
 
-NDTPPayloadBroadband NDTPPayloadBroadband::unpack(const ByteArray& data) {
+template <typename T>
+GenericNDTPPayloadBroadband<uint64_t> GenericNDTPPayloadBroadband<T>::unpack(const ByteArray& data) {
   if (data.size() < 7) {
     throw std::runtime_error("Invalid data size for NDTPPayloadBroadband");
   }

--- a/src/science/libndtp/ndtp.cpp
+++ b/src/science/libndtp/ndtp.cpp
@@ -95,15 +95,12 @@ ByteArray NDTPPayloadBroadband::pack() const {
     }
 
     auto p_cid = to_bytes<uint32_t>({c.channel_id}, 24, payload, bit_offset);
-    payload = std::get<0>(p_cid);
     bit_offset = std::get<1>(p_cid);
 
     auto p_num_samples = to_bytes<uint16_t>({static_cast<uint16_t>(num_samples)}, 16, payload, bit_offset);
-    payload = std::get<0>(p_num_samples);
     bit_offset = std::get<1>(p_num_samples);
 
     auto p_channel_data = to_bytes<uint64_t>(c.channel_data, bit_width, payload, bit_offset, is_signed);
-    payload = std::get<0>(p_channel_data);
     bit_offset = std::get<1>(p_channel_data);
   }
 

--- a/src/science/libndtp/ndtp.cpp
+++ b/src/science/libndtp/ndtp.cpp
@@ -69,8 +69,8 @@ NDTPHeader NDTPHeader::unpack(const ByteArray& data) {
   return NDTPHeader{version, data_type, ntohll(n_timestamp), ntohs(n_seq_number)};
 }
 
-template <typename Tinteger>
-ByteArray GenericNDTPPayloadBroadband<Tinteger>::pack() const {
+template <typename T>
+ByteArray GenericNDTPPayloadBroadband<T>::pack() const {
   ByteArray payload;
 
   // First byte: bit width and signed flag
@@ -101,7 +101,7 @@ ByteArray GenericNDTPPayloadBroadband<Tinteger>::pack() const {
     auto p_num_samples = to_bytes<uint16_t>({static_cast<uint16_t>(num_samples)}, 16, payload, bit_offset);
     bit_offset = std::get<1>(p_num_samples);
 
-    auto p_channel_data = to_bytes<Tinteger>(c.channel_data, bit_width, payload, bit_offset, is_signed);
+    auto p_channel_data = to_bytes<T>(c.channel_data, bit_width, payload, bit_offset, is_signed);
     bit_offset = std::get<1>(p_channel_data);
   }
 

--- a/src/science/libndtp/ndtp.cpp
+++ b/src/science/libndtp/ndtp.cpp
@@ -173,9 +173,10 @@ ByteArray NDTPPayloadSpiketrain::pack() const {
   // Pack bin_size_ms (1 byte)
   result.push_back(bin_size_ms);
 
+  
   // pack clamped spike counts
-  auto [bytes, final_bit_offset, _] = to_bytes(clamped_counts, BIT_WIDTH_BINNED_SPIKES, {}, 0);
-  result.insert(result.end(), bytes.begin(), bytes.end());
+  auto [bytes, final_bit_offset, _] = to_bytes(clamped_counts, BIT_WIDTH_BINNED_SPIKES, result, 0);
+  // result.insert(result.end(), bytes.begin(), bytes.end());
 
   return result;
 }

--- a/src/science/libndtp/ndtp.cpp
+++ b/src/science/libndtp/ndtp.cpp
@@ -139,7 +139,6 @@ ByteArray NDTPPayloadSpiketrain::pack() const {
   
   // pack clamped spike counts
   auto [bytes, final_bit_offset, _] = to_bytes(clamped_counts, BIT_WIDTH_BINNED_SPIKES, result, 0);
-  // result.insert(result.end(), bytes.begin(), bytes.end());
 
   return result;
 }

--- a/test/test_utils.cpp
+++ b/test/test_utils.cpp
@@ -26,12 +26,15 @@ TEST(UtilsTest, ToBytesBasicFunctionality) {
   EXPECT_EQ(offset4, 0);
   EXPECT_TRUE(success4);
 
-  auto [result5, offset5, success5] = to_bytes<uint64_t>({7, 5, 3}, 12, {0x01, 0x00}, 4);
+
+  ByteArray existing1 = {0x01, 0x00};
+  auto [result5, offset5, success5] = to_bytes<uint64_t>({7, 5, 3}, 12, existing1, 4);
   EXPECT_EQ(result5, (std::vector<uint8_t>{0x01, 0x00, 0x07, 0x00, 0x50, 0x03}));
   EXPECT_EQ(offset5, 0);
   EXPECT_TRUE(success5);
 
-  auto [result6, offset6, success6] = to_bytes<int64_t>({-7, -5, -3}, 12, {0x01, 0x00}, 4, true);
+  ByteArray existing2 = {0x01, 0x00};
+  auto [result6, offset6, success6] = to_bytes<int64_t>({-7, -5, -3}, 12, existing2, 4, true);
   EXPECT_EQ(result6, (std::vector<uint8_t>{0x01, 0x0F, 0xF9, 0xFF, 0xBF, 0xFD}));
   EXPECT_EQ(offset6, 0);
   EXPECT_TRUE(success6);

--- a/test/test_utils.cpp
+++ b/test/test_utils.cpp
@@ -21,7 +21,8 @@ TEST(UtilsTest, ToBytesBasicFunctionality) {
   EXPECT_EQ(offset3, 0);
   EXPECT_TRUE(success3);
 
-  auto [result4, offset4, success4] = to_bytes<int64_t>({-7, -5, -3, -1}, 12, {}, 0, true);
+  ByteArray existing = {};
+  auto [result4, offset4, success4] = to_bytes<int64_t>({-7, -5, -3, -1}, 12, existing, 0, true);
   EXPECT_EQ(result4, (std::vector<uint8_t>{0xFF, 0x9F, 0xFB, 0xFF, 0xDF, 0xFF}));
   EXPECT_EQ(offset4, 0);
   EXPECT_TRUE(success4);


### PR DESCRIPTION
The underlying representation of channel data in the `NDTPPayloadBroadband` struct is currently a vector of uint64s. This is nice for flexible data widths, but few use cases (if any) will ever need 64 bits of sample precision. Changing the struct to a template allows for a smaller data type (namely 16-bit ints) to be used. This also means that the struct can be constructed without copying all of the sample data into a new vector, significantly improving construction time. 

My primary motivation for this change is improving performance of this data type without disrupting other library consumers. However the same performance bump could be gained by just universally agreeing to support bit widths only up to 16 bits. 64 bits is frankly kind of over the top.

The `NDTPPayloadBroadband` type name is preserved as using 64-bit ints so not to break other library users. 