### PR TITLE
Switch to boost-crc for checksum computation

### DIFF
--- a/include/science/libndtp/utils.h
+++ b/include/science/libndtp/utils.h
@@ -7,25 +7,17 @@
 #include <utility>
 #include <vector>
 
+#include <boost/crc.hpp>
+
 namespace science::libndtp {
 
 using ByteArray = std::vector<uint8_t>;
 using BitOffset = size_t;
 
-inline uint16_t crc16(const ByteArray& data, uint16_t poly = 0x8005, uint16_t init = 0xFFFF) {
-  uint16_t crc = init;
-  for (const auto& byte : data) {
-    crc ^= byte << 8;
-    for (int i = 0; i < 8; ++i) {
-      if (crc & 0x8000) {
-        crc = (crc << 1) ^ poly;
-      } else {
-        crc <<= 1;
-      }
-      crc &= 0xFFFF;
-    }
-  }
-  return crc & 0xFFFF;
+inline uint16_t crc16(const ByteArray& data) {
+  boost::crc_16_type result;
+  result.process_bytes(data.data(), data.size());
+  return result.checksum();
 }
 
 /**

--- a/test/test_ndtp.cpp
+++ b/test/test_ndtp.cpp
@@ -178,12 +178,13 @@ TEST(NDTPTest, NDTPMessageBroadbandPackUnpack) {
 
   auto b = std::get<NDTPPayloadBroadband>(message.payload);
 
+  uint16_t expected_crc = 19660;
   auto packed = message.pack();
-  EXPECT_EQ(message._crc16, 23793);
+  EXPECT_EQ(message._crc16, expected_crc);
 
   EXPECT_EQ(
     to_hexstring(packed),
-    "01 02 00 00 00 00 49 96 02 d2 00 2a 18 00 00 03 00 00 03 00 00 00 00 01 00 00 00 00 10 00 20 00 3e 80 00 00 20 00 30 00 3e 87 d0 5c f1"
+    "01 02 00 00 00 00 49 96 02 d2 00 2a 18 00 00 03 00 00 03 00 00 00 00 01 00 00 00 00 10 00 20 00 3e 80 00 00 20 00 30 00 3e 87 d0 4c cc"
   );
 
   EXPECT_EQ(packed[0], 0x01);
@@ -198,12 +199,12 @@ TEST(NDTPTest, NDTPMessageBroadbandPackUnpack) {
   EXPECT_EQ(packed[9], 0xD2);
 
   uint16_t crc = (packed[packed.size() - 2] << 8) | packed[packed.size() - 1];
-  EXPECT_EQ(crc, 23793);
+  EXPECT_EQ(crc, expected_crc);
 
   auto unpacked = NDTPMessage::unpack(packed);
   EXPECT_EQ(unpacked.header, header) << "header is not equal to unpacked header";
   EXPECT_EQ(std::get<NDTPPayloadBroadband>(unpacked.payload), payload) << "payload is not equal to unpacked payload";
-  EXPECT_EQ(unpacked._crc16, 23793);
+  EXPECT_EQ(unpacked._crc16, expected_crc);
 
   auto unpacked_payload = std::get<NDTPPayloadBroadband>(unpacked.payload);
   EXPECT_EQ(unpacked_payload.channels.size(), payload.channels.size());
@@ -251,15 +252,16 @@ TEST(NDTPTest, NDTPMessageBroadbandPackUnpackLarge) {
   auto b = std::get<NDTPPayloadBroadband>(message.payload);
 
   auto packed = message.pack();
-  EXPECT_EQ(message._crc16, 45907);
+  uint16_t expected_crc = 32263;
+  EXPECT_EQ(message._crc16, expected_crc);
 
   uint16_t crc = (packed[packed.size() - 2] << 8) | packed[packed.size() - 1];
-  EXPECT_EQ(crc, 45907);
+  EXPECT_EQ(crc, expected_crc);
 
   auto unpacked = NDTPMessage::unpack(packed);
   EXPECT_EQ(unpacked.header, header) << "header is not equal to unpacked header";
   EXPECT_EQ(std::get<NDTPPayloadBroadband>(unpacked.payload), payload) << "payload is not equal to unpacked payload";
-  EXPECT_EQ(unpacked._crc16, 45907);
+  EXPECT_EQ(unpacked._crc16, expected_crc);
 
   auto unpacked_payload = std::get<NDTPPayloadBroadband>(unpacked.payload);
   EXPECT_EQ(unpacked_payload.channels.size(), payload.channels.size());
@@ -324,7 +326,7 @@ TEST(NDTPTest, NDTPMessageSpiketrainPackUnpack) {
     EXPECT_EQ(packed[19], 0xC0);  // 12,0 -> 1100 0000 -> 0xC0
 
     uint16_t crc = (packed[packed.size() - 2] << 8) | packed[packed.size() - 1];
-    EXPECT_EQ(crc, 22303);
+    EXPECT_EQ(crc, 40764);
   } else {
     FAIL() << "untested bit width for binned spikes";
   }

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,17 +1,23 @@
 {
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
+  "vcpkg-configuration": {
+    "overlay-ports": [
+      "./external/sciencecorp/vcpkg/ports"
+    ]
+  },
   "name": "science-libndtp",
   "version": "0.1.0",
   "supports": "arm64 | x64 | linux | osx",
-  "default-features": [],
-  "dependencies": ["protobuf"],
-  "vcpkg-configuration": {
-    "overlay-ports": ["./external/sciencecorp/vcpkg/ports"]
-  },
+  "dependencies": [
+    "protobuf",
+    "boost-crc"
+  ],
   "features": {
     "tests": {
       "description": "libndtp test suite",
-      "dependencies": ["gtest"]
+      "dependencies": [
+        "gtest"
+      ]
     }
   }
 }


### PR DESCRIPTION
Addresses #7 . This does change the parameters of the CRC function to the defaults for boost crc16. I figure we arent particularly picky about what variant we are using. 

Benchmarked by measuring the average time to calculate the CRC16 for a NDTP broadband packet with 1000 12-bit samples from one channel (1526 bytes). Benchmarks were run 128000 iterations to get an average execution time. 
Old implementation: ~85 us per packet
Boost implementation: ~5.12 us per packet

Tests were run locally on Intel i9-13900H